### PR TITLE
Add support for IE11 and MS Edge

### DIFF
--- a/ftw/iframeblock/browser/resources/styles.scss
+++ b/ftw/iframeblock/browser/resources/styles.scss
@@ -1,1 +1,11 @@
 @include portal-type-font-awesome-icon(ftw-iframeblock-iframeblock, file-code-o);
+
+//ie-only supports IE11 and MS Edge.
+//IE10 and older MS browsers don't know pointer-events, so this selector won't work for them.
+@include ie-only(".sl-can-edit .ftw-iframeblock-iframeblock .sl-block-content") {
+  cursor: not-allowed;
+}
+
+@include ie-only(".sl-can-edit .ftw-iframeblock-iframeblock iframe") {
+  pointer-events: none;
+}


### PR DESCRIPTION
Use ie-only selector to show IE users, that the edit functionality is not supported in their browser.
IE10 and older MS browsers don't know pointer-events, so this selector wont work for them.

closes #2 
