### PR TITLE
Remove metadata.xml-dependencie to ftw.simplelayout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Introduction
 ============
 
+*This package is an addon for `ftw.simplelayout <http://github.com/4teamwork/ftw.simplelayout>`_. Please make sure you
+already installed `ftw.simplelayout` on your plone site before installing this addon.*
+
 ``ftw.iframeblock`` privides a block for ``ftw.simplelayout``, which renders a iframe using
 `iframeResizer.js <https://github.com/davidjbradshaw/iframe-resizer#typical-setup>`_.
 Read carefully the setup instroctions of iframeresizer, you need a implementation on both domains.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove metadata.xml-dependencie to ftw.simplelayout.
+  This package is an addon of ftw.simplelayout and should not install it.
+  [elioschmutz]
 
 1.0.2 (2016-07-08)
 ------------------

--- a/ftw/iframeblock/profiles/default/metadata.xml
+++ b/ftw/iframeblock/profiles/default/metadata.xml
@@ -2,6 +2,5 @@
 <metadata>
     <version>1000</version>
     <dependencies>
-        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/iframeblock/testing.py
+++ b/ftw/iframeblock/testing.py
@@ -26,6 +26,7 @@ class FtwLayer(PloneSandboxLayer):
         z2.installProduct(app, 'ftw.simplelayout')
 
     def setUpPloneSite(self, portal):
+        applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.iframeblock:default')
 
 


### PR DESCRIPTION
This package is an addon of ftw.simplelayout and should not install it.
