### PR TITLE
Allow opening sub-page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,41 @@
+.. contents:: Table of Contents
+
 Introduction
 ============
 
-This package is an addon for `ftw.simplelayout <http://github.com/4teamwork/ftw.simplelayout>`_. Please make sure you
-already installed ``ftw.simplelayout`` on your plone site before installing this addon.
+This package is an addon for `ftw.simplelayout`_.
+Please make sure you already installed `ftw.simplelayout`_
+on your plone site before installing this addon.
 
-``ftw.iframeblock`` privides a block for ``ftw.simplelayout``, which renders a iframe using
-`iframeResizer.js <https://github.com/davidjbradshaw/iframe-resizer#typical-setup>`_.
-Read carefully the setup instroctions of iframeresizer, you need a implementation on both domains.
+``ftw.iframeblock`` privides a block for `ftw.simplelayout`_,
+which renders a iframe using `iframe-resizer`_.
+Read the setup instructions of iframeresizer carefully:
+you need an implementation on both domains.
 
 
-.. contents:: Table of Contents
+Linking to sub pages
+--------------------
+
+When integrating other websites in iframes and indexing those
+contents in the search, we want to be able to link from the search
+to a specific iframed sub-page.
+
+In order to make this possible we need to be able to pass the requested
+sub-page as GET request param.
+
+For security reason, the origin of both URLs must be the same, otherwise the configured startpage is loaded.
+
+**Examples:**
+
+- ``http://localhost:8080/Plone/the-page?i=http://foo.ch/bar/baz.php``
+- ``http://localhost:8080/Plone/the-page?i_iframeblock2=http://foo.ch/bar/baz.php``
+
+
+Compatibility
+-------------
+
+Runs with `Plone <http://www.plone.org/>`_ `4.3.x`.
+
 
 Installation local development-environment
 ------------------------------------------
@@ -23,36 +49,6 @@ Installation local development-environment
     $ bin/buildout
     $ bin/instance fg
 
-Dev-Test-Release-Process
-------------------------
-
-If you want to develop features, you must follow this guide
-
-First checkout the package and create a new branch from the master:
-
-.. code:: bash
-
-    $ git clone git@github.com:4teamwork/ftw.iframeblock.git
-    $ cd ftw.iframeblock
-    $ git checkout -b my-mew-feature
-    $ git push origin -u my-new-feature
-
-If you are finnished and the feature is working fine, you can merge it into the
-master branch after the quality-check:
-
-.. code:: bash
-
-    $ git checkout master
-    $ git merge my-mew-feature
-    $ git push
-
-Now, the feature is available for other developers.
-
-
-Compatibility
--------------
-
-Runs with `Plone <http://www.plone.org/>`_ `4.3.x`.
 
 
 Links
@@ -68,3 +64,6 @@ Copyright
 This package is copyright by `4teamwork <http://www.4teamwork.ch/>`_.
 
 ``ftw.iframeblock`` is licensed under GNU General Public License, version 2.
+
+.. _ftw.simplelayout: http://github.com/4teamwork/ftw.simplelayout
+.. _iframe-resizer: https://github.com/davidjbradshaw/iframe-resizer

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Allow opening sub-page by passing it as GET parameter "i". [jone]
+
 - Update description of edit view.
   [raphael-s]
 

--- a/ftw/iframeblock/browser/iframeblock.py
+++ b/ftw/iframeblock/browser/iframeblock.py
@@ -1,5 +1,6 @@
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from plone import api
+from urlparse import urlparse
 
 
 class IFrameBlockView(BaseBlock):
@@ -8,3 +9,28 @@ class IFrameBlockView(BaseBlock):
 
     def can_add(self):
         return api.user.has_permission('ftw.iframeblock: Add iFrame block')
+
+    def get_url(self):
+        url = self.request.get('i_{}'.format(self.context.getId()),
+                               self.request.get('i', None))
+        if url and self.is_valid_url(url):
+            return url
+        else:
+            return self.context.url
+
+    def is_valid_url(self, url):
+        url = urlparse(url)
+        if not url.netloc:
+            # URL is not fully qualified
+            return False
+
+        if url.scheme not in ('http', 'https'):
+            # URL is not http
+            return False
+
+        standard_url = urlparse(self.context.url)
+        if url.netloc != standard_url.netloc:
+            # Different domain
+            return False
+
+        return True

--- a/ftw/iframeblock/browser/templates/iframeblock.pt
+++ b/ftw/iframeblock/browser/templates/iframeblock.pt
@@ -3,7 +3,11 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.iframeblock">
 
-    <iframe tal:attributes="src context/url; height context/height" width="100%" scrolling="no" class="iframeblock"></iframe>
+    <iframe tal:attributes="src view/get_url;
+                            height context/height"
+            width="100%"
+            scrolling="no"
+            class="iframeblock"></iframe>
     <script tal:condition="context/auto_size">iFrameResize()</script>
 
 </html>

--- a/ftw/iframeblock/tests/test_iframeblock.py
+++ b/ftw/iframeblock/tests/test_iframeblock.py
@@ -68,3 +68,66 @@ class TestIFrameBlock(FunctionalTestCase):
             'no',
             browser.css('iframe.iframeblock').first.attrib['scrolling']
         )
+
+    @browsing
+    def test_alternative_url_can_be_passed_as_request_param(self, browser):
+        """
+        When integrating other websites in iframes and indexing those
+        contents in the search, we want to be able to link from the search
+        to a specific iframed sub-page.
+        In order to make this possible we need to be able to pass the
+        requested sub-page as GET request param.
+        For security reason, the origin of both URLs must be the same,
+        otherwise the configured startpage is loaded.
+        """
+        content_page = create(Builder('sl content page'))
+
+        block = create(Builder('iframe block')
+                       .titled('the-block')
+                       .having(url=u'http://mypage.com/index.php')
+                       .within(content_page))
+
+        browser.login().visit(content_page)
+        self.assertEqual(
+            u'http://mypage.com/index.php',
+            browser.css('iframe.iframeblock').first.attrib['src'])
+
+        # "i", shortcut for "iframe" is the non-specific param
+        browser.visit(content_page, data={
+            'i': u'http://mypage.com/contact.php'})
+        self.assertEqual(
+            u'http://mypage.com/contact.php',
+            browser.css('iframe.iframeblock').first.attrib['src'],
+            'Using "?i=<URL>" should load the passed URL.')
+
+        # "i_<ID>" can be used for beeing more specific
+        browser.visit(content_page, data={
+            'i_the-block': u'http://mypage.com/contact.php'})
+        self.assertEqual(
+            u'http://mypage.com/contact.php',
+            browser.css('iframe.iframeblock').first.attrib['src'],
+            'Using "?i_<BLOCKID>=<URL>" should load the passed URL.')
+
+        # domain must match
+        browser.visit(content_page, data={
+            'i': u'http://hacker.com/contact.php'})
+        self.assertEqual(
+            u'http://mypage.com/index.php',
+            browser.css('iframe.iframeblock').first.attrib['src'],
+            'Non-matching domains are not allowed.')
+
+        # switch to https is allowed
+        browser.visit(content_page, data={
+            'i': u'https://mypage.com/contact.php'})
+        self.assertEqual(
+            u'https://mypage.com/contact.php',
+            browser.css('iframe.iframeblock').first.attrib['src'],
+            'Switching to HTTPS is allowed.')
+
+        # switch to other protocols is not allowed
+        browser.visit(content_page, data={
+            'i': u'file://mypage.com/contact.php'})
+        self.assertEqual(
+            u'http://mypage.com/index.php',
+            browser.css('iframe.iframeblock').first.attrib['src'],
+            'Switching to file:// is not allowed.')


### PR DESCRIPTION
When integrating other websites in iframes and indexing those contents in the search, we want to be able to link from the search to a specific iframed sub-page.
In order to make this possible we need to be able to pass the requested sub-page as GET request param.
For security reason, the origin of both URLs must be the same, otherwise the configured startpage is loaded.

Examples:
- `http://localhost:8080/Plone/the-page?i=http://foo.ch/bar/baz.php`
- `http://localhost:8080/Plone/the-page?i_iframeblock2=http://foo.ch/bar/baz.php`
