### PR TITLE
Make IFrameBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make IFrameBlock addable on plone site per default [raphael-s]
 
 
 1.3.2 (2017-01-17)
@@ -19,7 +19,7 @@ Changelog
 ------------------
 
 - Well... implement IE compatible spinner, which does not changes the bg color
-  of the iframe. 
+  of the iframe.
   [mathias.leimgruber]
 
 

--- a/ftw/iframeblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/iframeblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.iframeblock.IFrameBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.iframeblock` is installed the IFrameBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the IFrameBlock.