### PR TITLE
Enable scrolling fallback when the iframe resizer is disabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Enable scrolling fallback when the iframe resizer is disabled. [lknoepfel]
+ 
 - Make iframe fixes compatible with ftw.iframefix 2.0. [Kevin Bieri]
 
 - Install ftw.iframefix

--- a/ftw/iframeblock/browser/templates/iframeblock.pt
+++ b/ftw/iframeblock/browser/templates/iframeblock.pt
@@ -5,9 +5,9 @@
 
     <div class="iframeSpinner loading"></div>
     <iframe tal:attributes="src view/get_url;
-                            height context/height"
+                            height context/height;
+                            scrolling python:'no' if context.auto_size else 'auto'"
             width="100%"
-            scrolling="no"
             class="iframeblock loading" onload="onIframeLoaded(this)"></iframe>
     <script tal:condition="context/auto_size">iFrameResize()</script>
 

--- a/ftw/iframeblock/tests/test_content_type.py
+++ b/ftw/iframeblock/tests/test_content_type.py
@@ -27,8 +27,8 @@ class TestIFrameBlockContentType(FunctionalTestCase):
 
         self.assertTrue(len(browser.css('.sl-block')), 'Expect one block')
         self.assertEqual(
-            '<iframe width="100%" scrolling="no" class="iframeblock loading" '
+            '<iframe width="100%" class="iframeblock loading" '
             'onload="onIframeLoaded(this)" src="http://www.google.com" '
-            'height="400"></iframe>',
+            'scrolling="auto" height="400"></iframe>',
             browser.css('iframe.iframeblock').first.outerHTML
         )

--- a/ftw/iframeblock/tests/test_iframeblock.py
+++ b/ftw/iframeblock/tests/test_iframeblock.py
@@ -32,8 +32,7 @@ class TestIFrameBlock(FunctionalTestCase):
     @browsing
     def test_height_field_is_used_if_auto_size_is_not_set(self, browser):
         """
-        This test makes sure that the url passed to the creation form is added
-        to the iframe tag correctly.
+        Test that the height set in the block is applied to the iframe.
         """
         content_page = create(Builder('sl content page'))
 
@@ -51,21 +50,34 @@ class TestIFrameBlock(FunctionalTestCase):
         )
 
     @browsing
-    def test_scrolling_always_set_to_no(self, browser):
+    def test_scrolling_attribute_depending_on_auto_resize(self, browser):
         """
-        This test makes sure that the url passed to the creation form is added
-        to the iframe tag correctly.
+        The scrolling attribute has to be set to no if the iframe resizer is
+        in use to avoid jittering.
+        When the resizier is disabled the iframe should handle the scrollbars.
+        (-> scrolling: auto)
         """
-        content_page = create(Builder('sl content page'))
-
+        with_resizer = create(Builder('sl content page'))
         create(Builder('iframe block')
-               .having(url=u'http://www.google.com')
-               .within(content_page))
+               .having(url=u'http://www.google.com',
+                       auto_size=True)
+               .within(with_resizer))
 
-        browser.login().visit(content_page)
+        without_resizer = create(Builder('sl content page'))
+        create(Builder('iframe block')
+               .having(url=u'http://www.google.com',
+                       auto_size=False)
+               .within(without_resizer))
 
+        browser.login().visit(with_resizer)
         self.assertEqual(
             'no',
+            browser.css('iframe.iframeblock').first.attrib['scrolling']
+        )
+
+        browser.visit(without_resizer)
+        self.assertEqual(
+            'auto',
             browser.css('iframe.iframeblock').first.attrib['scrolling']
         )
 


### PR DESCRIPTION
This change enables the native scrolling on the iframe only if the iframe resizer is disabled. This prevents possible unwanted interactions and jittering.

Now if the website included with the iframe is bigger than the iframe scrollbars are displayed.

The height of the iframe can still be configured with the height property.