### PR TITLE
Always scroll to top of iframe after new page is loaded

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,14 +5,16 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow usage of anchor links inside iFrame block [raphael-s]
+- Always scroll a bit above iFrameblock after a new page has been loaded
+  inside the block [raphael-s]
 
 
 1.3.4 (2017-07-25)
 ------------------
 
 - Enable scrolling fallback when the iframe resizer is disabled. [lknoepfel]
- 
+
 - Make iframe fixes compatible with ftw.iframefix 2.0. [Kevin Bieri]
 
 - Install ftw.iframefix

--- a/ftw/iframeblock/browser/templates/iframeblock.pt
+++ b/ftw/iframeblock/browser/templates/iframeblock.pt
@@ -9,6 +9,13 @@
                             scrolling python:'no' if context.auto_size else 'auto'"
             width="100%"
             class="iframeblock loading" onload="onIframeLoaded(this)"></iframe>
-    <script tal:condition="context/auto_size">iFrameResize()</script>
+    <script tal:condition="context/auto_size">
+      iFrameResize({
+        inPageLinks: true,
+        resizedCallback: function () {
+          scroll(0, 0);
+        }
+      })
+    </script>
 
 </html>


### PR DESCRIPTION
Also allow the use of anchor links inside the iframe.

Those changes were requested by a customer, maybe we have to make a config for the iframblock so every user can decide wether they want auto scroll or not. But atm this is not a requirement.